### PR TITLE
Use is-generator-function instead of is-generator to detect generator functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "native-or-bluebird": "1",
     "awaitable": "1",
-    "is-generator": "1"
+    "is-generator-function": "~1.0.0"
   },
   "devDependencies": {
     "bluebird": "2",

--- a/slave.js
+++ b/slave.js
@@ -1,6 +1,6 @@
 
 var co = require('awaitable')
-var isGenFun = require('is-generator').fn
+var isGenFun = require('is-generator-function')
 
 module.exports = function (fn) {
   if (isGenFun(fn)) fn = co.wrap(fn)


### PR DESCRIPTION
This switches from "is-generator", which uses easily fakeable constructor properties to test for generator functions, with "is-generator-function", which uses unfakeable Function#toString to test for generator functions.
